### PR TITLE
[Add]rubyとunicornのバージョン変更 #111

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-ruby '3.0.0'
+ruby '2.7.2'
 
 gem 'rails', '6.1.3.1'
 
@@ -94,5 +94,5 @@ group :test do
 end
 
 group :production, :staging do
-  gem 'unicorn'
+  gem 'unicorn', '5.4.1'
 end


### PR DESCRIPTION
rubyを2.7.2、unicornを5.4.1にダウングレード。
（ruby3.0.0がunicornに対応していないため）