### PR TITLE
[Fix]メイラーでURL生成のため:hostパラメータを指定 #123

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,8 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "shortcut_plus_production"
 
   config.action_mailer.perform_caching = false
+
+  config.action_mailer.default_url_options = { host: 'www.shortcutplus.com'}
   config.action_mailer.delivery_method = :aws_sdk
 
   # Ignore bad email addresses and do not raise email delivery errors.


### PR DESCRIPTION
メイラーでURL生成のため、production環境で`:host`パラメータを指定。