### PR TITLE
[Fix]アドレス変更メールの認証URLアクセス時にログイン不要で認証できるよう修正 #123

### DIFF
--- a/app/controllers/email_changes_controller.rb
+++ b/app/controllers/email_changes_controller.rb
@@ -1,4 +1,5 @@
 class EmailChangesController < ApplicationController
+  skip_before_action :require_login, only: %i[edit]
   before_action :set_categories
 
   def new; end


### PR DESCRIPTION
アドレス変更メールの認証URLアクセス時にログイン不要で認証できるように修正。